### PR TITLE
refactor(communications-layer-lib): move path for connecting to socket_transport_layer constructor

### DIFF
--- a/src/command-manager.cpp
+++ b/src/command-manager.cpp
@@ -46,7 +46,7 @@ int main(__attribute__((unused)) int argc, __attribute__((unused)) char *argv[])
 
     console = interactive_console::get_instance();
 
-    transport_layer = new socket_transport_layer();
+    transport_layer = new socket_transport_layer(argparser->get_remote_path());
     application_layer = new slip_application_layer();
     application_layer->set_next_communications_layer(transport_layer);
 

--- a/src/command-manager/src/command-manager.cpp
+++ b/src/command-manager/src/command-manager.cpp
@@ -10,7 +10,7 @@ int command_manager::send_simple_cmd(const char *cmd, size_t cmd_size) {
     char response[32];
 
     printf("command_manager::send_simple_cmd send '%s' [%zu]\r\n", cmd, cmd_size);
-    int ret = socket->connect_socket(send_cmd_socket_path);
+    int ret = socket->connect_socket();
     if (ret == -1) {
         perror("fast_command::execute: connect_socket");
         return -2;
@@ -50,7 +50,7 @@ int command_manager::send_slow_cmd(char *response_buffer, size_t response_buffer
 
     printf("command_manager::send_slow_cmd send '%s' [%zu]\r\n", command_ids::slow_cmd_id,
            sizeof(command_ids::slow_cmd_id));
-    int ret = socket->connect_socket(send_cmd_socket_path);
+    int ret = socket->connect_socket();
     if (ret == -1) {
         perror("fast_command::execute: connect_socket");
         return -2;

--- a/src/command-manager/test/test-command-manager.cpp
+++ b/src/command-manager/test/test-command-manager.cpp
@@ -32,7 +32,8 @@ class CommunicationsLayerMock : public communications_layer_interface {
 
 class SocketTransportLayerMock : public socket_transport_layer {
   public:
-    MOCK_METHOD(int, connect_socket, (const char *));
+    SocketTransportLayerMock() : socket_transport_layer("") {}
+    MOCK_METHOD(int, connect_socket, ());
     MOCK_METHOD(int, disconnect_socket, ());
     MOCK_METHOD(int, listen_connections, (const char *, communications_layer_observer *));
     MOCK_METHOD(ssize_t, send, (const char *, size_t), (override));
@@ -124,7 +125,7 @@ class TestCommandManager : public testing::TestWithParam<TestCommandManagerParam
 };
 
 TEST_P(TestCommandManager, TestNextSendHandlerMessage) {
-    EXPECT_CALL(*socket_mock, connect_socket(_)).Times(AnyNumber()).WillRepeatedly(Return(0));
+    EXPECT_CALL(*socket_mock, connect_socket()).Times(AnyNumber()).WillRepeatedly(Return(0));
     EXPECT_CALL(*communications_layer_mock, send(StrEq(GetParam().expected_cmd), GetParam().expected_cmd_size))
         .Times(1)
         .WillOnce(Return(GetParam().send_expected_result));

--- a/src/communications-layer/include/communications-layer/socket-transport-layer.hpp
+++ b/src/communications-layer/include/communications-layer/socket-transport-layer.hpp
@@ -6,11 +6,11 @@
 
 class socket_transport_layer : public communications_layer {
   public:
-    socket_transport_layer();
+    socket_transport_layer(const char *socket_path);
 
     ~socket_transport_layer();
 
-    int connect_socket(const char *socket_path);
+    int connect_socket();
 
     int disconnect_socket();
 
@@ -25,6 +25,7 @@ class socket_transport_layer : public communications_layer {
     int shutdown() override;
 
   private:
+    char *socket_path;
     int sending_socket;
     int listening_socket;
     bool is_listening;


### PR DESCRIPTION
closes #91 